### PR TITLE
use falling block entity instead of shulker

### DIFF
--- a/src/main/java/adhdmc/villagerinfo/Commands/SubCommands/ToggleCommand.java
+++ b/src/main/java/adhdmc/villagerinfo/Commands/SubCommands/ToggleCommand.java
@@ -40,12 +40,12 @@ public class ToggleCommand extends SubCommand {
 
     private boolean toggleSetting(Player player) {
         PersistentDataContainer playerPDC = player.getPersistentDataContainer();
-        byte togglePDC = playerPDC.getOrDefault(VillagerInfo.getInfoEnabledKey(), PersistentDataType.BYTE, (byte)0);
+        byte togglePDC = playerPDC.getOrDefault(VillagerInfo.INFO_ENABLED_KEY, PersistentDataType.BYTE, (byte)0);
         if (togglePDC == 1) {
-            playerPDC.set(VillagerInfo.getInfoEnabledKey(), PersistentDataType.BYTE, (byte)0);
+            playerPDC.set(VillagerInfo.INFO_ENABLED_KEY, PersistentDataType.BYTE, (byte)0);
             return false;
         }
-        playerPDC.set(VillagerInfo.getInfoEnabledKey(), PersistentDataType.BYTE, (byte)1);
+        playerPDC.set(VillagerInfo.INFO_ENABLED_KEY, PersistentDataType.BYTE, (byte)1);
         return true;
     }
 

--- a/src/main/java/adhdmc/villagerinfo/VillagerHandling/HighlightHandling.java
+++ b/src/main/java/adhdmc/villagerinfo/VillagerHandling/HighlightHandling.java
@@ -17,10 +17,10 @@ public class HighlightHandling {
     private static final double CENTER = 0.5;
     private static final double OFFSET = -0.001;
     private static final int MAX_FALL_DISTANCE = -2147483648;
-    private static NamespacedKey highlightStatus = new NamespacedKey(VillagerInfo.getInstance(), "highlighted");
+    private static final NamespacedKey HIGHLIGHT_STATUS = new NamespacedKey(VillagerInfo.getInstance(), "highlighted");
 
-    public static HashMap<UUID, FallingBlock> workstationHighlightBlock = new HashMap<>();
-    public static HashMap<UUID, PersistentDataContainer> villagerPDC = new HashMap<>();
+    public static final HashMap<UUID, FallingBlock> WORKSTATION_HIGHLIGHT_BLOCK = new HashMap<>();
+    public static final HashMap<UUID, PersistentDataContainer> VILLAGER_PDC = new HashMap<>();
 
     /**
      * villagerJobsiteHighlight
@@ -29,14 +29,14 @@ public class HighlightHandling {
      * @param villPOI the villager's Point Of Interest Location
      */
     public static void villagerJobsiteHighlight(PersistentDataContainer villPDC, UUID villUUID, Location villPOI) {
-        if (villPDC.getOrDefault(highlightStatus, PersistentDataType.BYTE, (byte)0) == 1) return;
-        villPDC.set(highlightStatus, PersistentDataType.BYTE, (byte)1);
-        villagerPDC.put(villUUID, villPDC);
+        if (villPDC.getOrDefault(HIGHLIGHT_STATUS, PersistentDataType.BYTE, (byte)0) == 1) return;
+        villPDC.set(HIGHLIGHT_STATUS, PersistentDataType.BYTE, (byte)1);
+        VILLAGER_PDC.put(villUUID, villPDC);
         spawnFallingBlock(villUUID, villPOI);
         Bukkit.getScheduler().runTaskLater(VillagerInfo.getInstance(), () -> {
             killFallingBlock(villUUID);
-            villPDC.set(highlightStatus, PersistentDataType.BYTE, (byte)0);
-            villagerPDC.put(villUUID, villPDC);
+            villPDC.set(HIGHLIGHT_STATUS, PersistentDataType.BYTE, (byte)0);
+            VILLAGER_PDC.put(villUUID, villPDC);
         }, 20L * ConfigValidator.configTime);
     }
 
@@ -56,7 +56,7 @@ public class HighlightHandling {
         fallingBlock.setGravity(false);
         fallingBlock.setFallDistance(MAX_FALL_DISTANCE);
 
-        workstationHighlightBlock.put(villUUID, fallingBlock);
+        WORKSTATION_HIGHLIGHT_BLOCK.put(villUUID, fallingBlock);
     }
 
     /**
@@ -64,7 +64,7 @@ public class HighlightHandling {
      * @param villUUID villager's UUID that the FallingBlock was attached to
      */
     public static void killFallingBlock(UUID villUUID) {
-        workstationHighlightBlock.get(villUUID).remove();
-        workstationHighlightBlock.remove(villUUID);
+        WORKSTATION_HIGHLIGHT_BLOCK.get(villUUID).remove();
+        WORKSTATION_HIGHLIGHT_BLOCK.remove(villUUID);
     }
 }

--- a/src/main/java/adhdmc/villagerinfo/VillagerHandling/HighlightHandling.java
+++ b/src/main/java/adhdmc/villagerinfo/VillagerHandling/HighlightHandling.java
@@ -5,19 +5,21 @@ import adhdmc.villagerinfo.VillagerInfo;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
-import org.bukkit.entity.Shulker;
-import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.FallingBlock;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
 import java.util.HashMap;
 import java.util.UUID;
 
-import static org.bukkit.entity.EntityType.SHULKER;
-
 public class HighlightHandling {
-    static NamespacedKey highlightStatus = new NamespacedKey(VillagerInfo.getInstance(), "highlighted");
-    public static HashMap<UUID, Shulker> workstationShulker = new HashMap<>();
+    private static final double CENTER = 0.5;
+    private static final double OFFSET = -0.001;
+    private static final int MAX_FALL_DISTANCE = -2147483648;
+    private static NamespacedKey highlightStatus = new NamespacedKey(VillagerInfo.getInstance(), "highlighted");
+
+    public static HashMap<UUID, FallingBlock> workstationHighlightBlock = new HashMap<>();
     public static HashMap<UUID, PersistentDataContainer> villagerPDC = new HashMap<>();
 
     /**
@@ -30,38 +32,39 @@ public class HighlightHandling {
         if (villPDC.getOrDefault(highlightStatus, PersistentDataType.BYTE, (byte)0) == 1) return;
         villPDC.set(highlightStatus, PersistentDataType.BYTE, (byte)1);
         villagerPDC.put(villUUID, villPDC);
-        spawnShulker(villUUID, villPOI);
+        spawnFallingBlock(villUUID, villPOI);
         Bukkit.getScheduler().runTaskLater(VillagerInfo.getInstance(), () -> {
-            killShulker(villUUID);
+            killFallingBlock(villUUID);
             villPDC.set(highlightStatus, PersistentDataType.BYTE, (byte)0);
             villagerPDC.put(villUUID, villPDC);
         }, 20L * ConfigValidator.configTime);
     }
 
     /**
-     * spawnShulker
+     * spawnFallingBlock
      * @param villUUID the villager's UUID
-     * @param location location to spawn the Shulker
+     * @param location location to spawn the FallingBlock
      */
-    private static void spawnShulker(UUID villUUID, Location location) {
-        Shulker spawnedShulker = (Shulker) location.getWorld().spawnEntity(location, SHULKER, CreatureSpawnEvent.SpawnReason.CUSTOM, (entity) -> {
-            Shulker highlightbox = (Shulker) entity;
-            highlightbox.setAI(false);
-            highlightbox.setAware(false);
-            highlightbox.setCollidable(false);
-            highlightbox.setGlowing(true);
-            highlightbox.setInvisible(true);
-            highlightbox.setInvulnerable(true);
-        });
-        workstationShulker.put(villUUID, spawnedShulker);
+    private static void spawnFallingBlock(UUID villUUID, Location location) {
+        BlockData blockData = location.getBlock().getBlockData();
+        // spawn entity a bit lower than the original block, otherwise the glow won't show
+        Location fallingBlockLocation = location.add(CENTER, OFFSET, CENTER);
+
+        FallingBlock fallingBlock = location.getWorld().spawnFallingBlock(fallingBlockLocation, blockData);
+        fallingBlock.setGlowing(true);
+        // setting fall distance to it's max w/ gravity disabled makes it "fall infinitely"
+        fallingBlock.setGravity(false);
+        fallingBlock.setFallDistance(MAX_FALL_DISTANCE);
+
+        workstationHighlightBlock.put(villUUID, fallingBlock);
     }
 
     /**
-     * killShulker
-     * @param villUUID villager's UUID that the shulker was attached to
+     * killFallingBlock
+     * @param villUUID villager's UUID that the FallingBlock was attached to
      */
-    public static void killShulker(UUID villUUID) {
-        workstationShulker.get(villUUID).remove();
-        workstationShulker.remove(villUUID);
+    public static void killFallingBlock(UUID villUUID) {
+        workstationHighlightBlock.get(villUUID).remove();
+        workstationHighlightBlock.remove(villUUID);
     }
 }

--- a/src/main/java/adhdmc/villagerinfo/VillagerHandling/HighlightHandling.java
+++ b/src/main/java/adhdmc/villagerinfo/VillagerHandling/HighlightHandling.java
@@ -4,7 +4,6 @@ import adhdmc.villagerinfo.Config.ConfigValidator;
 import adhdmc.villagerinfo.VillagerInfo;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.NamespacedKey;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.FallingBlock;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -17,7 +16,6 @@ public class HighlightHandling {
     private static final double CENTER = 0.5;
     private static final double OFFSET = -0.001;
     private static final int MAX_FALL_DISTANCE = -2147483648;
-    private static final NamespacedKey HIGHLIGHT_STATUS = new NamespacedKey(VillagerInfo.getInstance(), "highlighted");
 
     public static final HashMap<UUID, FallingBlock> WORKSTATION_HIGHLIGHT_BLOCK = new HashMap<>();
     public static final HashMap<UUID, PersistentDataContainer> VILLAGER_PDC = new HashMap<>();
@@ -29,13 +27,13 @@ public class HighlightHandling {
      * @param villPOI the villager's Point Of Interest Location
      */
     public static void villagerJobsiteHighlight(PersistentDataContainer villPDC, UUID villUUID, Location villPOI) {
-        if (villPDC.getOrDefault(HIGHLIGHT_STATUS, PersistentDataType.BYTE, (byte)0) == 1) return;
-        villPDC.set(HIGHLIGHT_STATUS, PersistentDataType.BYTE, (byte)1);
+        if (villPDC.getOrDefault(VillagerInfo.HIGHLIGHT_STATUS, PersistentDataType.BYTE, (byte)0) == 1) return;
+        villPDC.set(VillagerInfo.HIGHLIGHT_STATUS, PersistentDataType.BYTE, (byte)1);
         VILLAGER_PDC.put(villUUID, villPDC);
         spawnFallingBlock(villUUID, villPOI);
         Bukkit.getScheduler().runTaskLater(VillagerInfo.getInstance(), () -> {
             killFallingBlock(villUUID);
-            villPDC.set(HIGHLIGHT_STATUS, PersistentDataType.BYTE, (byte)0);
+            villPDC.set(VillagerInfo.HIGHLIGHT_STATUS, PersistentDataType.BYTE, (byte)0);
             VILLAGER_PDC.put(villUUID, villPDC);
         }, 20L * ConfigValidator.configTime);
     }

--- a/src/main/java/adhdmc/villagerinfo/VillagerHandling/VillagerHandler.java
+++ b/src/main/java/adhdmc/villagerinfo/VillagerHandling/VillagerHandler.java
@@ -34,7 +34,7 @@ public class VillagerHandler implements Listener {
     public void onVillagerClick(PlayerInteractEntityEvent event) {
         Player player = event.getPlayer();
         PersistentDataContainer playerPDC = player.getPersistentDataContainer();
-        byte togglePDC = playerPDC.getOrDefault(VillagerInfo.getInfoEnabledKey(), PersistentDataType.BYTE, (byte)0);
+        byte togglePDC = playerPDC.getOrDefault(VillagerInfo.INFO_ENABLED_KEY, PersistentDataType.BYTE, (byte)0);
         if (togglePDC == 0) {
             return;
         }

--- a/src/main/java/adhdmc/villagerinfo/VillagerInfo.java
+++ b/src/main/java/adhdmc/villagerinfo/VillagerInfo.java
@@ -46,9 +46,9 @@ public final class VillagerInfo extends JavaPlugin {
     }
 
     public void onDisable() {
-        HighlightHandling.workstationHighlightBlock.forEach((uuid, fallingBlock) -> fallingBlock.remove());
-        HighlightHandling.villagerPDC.forEach((uuid, persistentDataContainer) -> persistentDataContainer.remove(new NamespacedKey(VillagerInfo.instance, "highlightStatus")));
-        HighlightHandling.workstationHighlightBlock.clear();
+        HighlightHandling.WORKSTATION_HIGHLIGHT_BLOCK.forEach((uuid, fallingBlock) -> fallingBlock.remove());
+        HighlightHandling.VILLAGER_PDC.forEach((uuid, persistentDataContainer) -> persistentDataContainer.remove(new NamespacedKey(VillagerInfo.instance, "highlightStatus")));
+        HighlightHandling.WORKSTATION_HIGHLIGHT_BLOCK.clear();
     }
 
     private void registerCommands() {

--- a/src/main/java/adhdmc/villagerinfo/VillagerInfo.java
+++ b/src/main/java/adhdmc/villagerinfo/VillagerInfo.java
@@ -46,9 +46,9 @@ public final class VillagerInfo extends JavaPlugin {
     }
 
     public void onDisable() {
-        HighlightHandling.workstationShulker.forEach((uuid, shulker) -> shulker.remove());
+        HighlightHandling.workstationHighlightBlock.forEach((uuid, fallingBlock) -> fallingBlock.remove());
         HighlightHandling.villagerPDC.forEach((uuid, persistentDataContainer) -> persistentDataContainer.remove(new NamespacedKey(VillagerInfo.instance, "highlightStatus")));
-        HighlightHandling.workstationShulker.clear();
+        HighlightHandling.workstationHighlightBlock.clear();
     }
 
     private void registerCommands() {

--- a/src/main/java/adhdmc/villagerinfo/VillagerInfo.java
+++ b/src/main/java/adhdmc/villagerinfo/VillagerInfo.java
@@ -18,8 +18,8 @@ public final class VillagerInfo extends JavaPlugin {
     private static VillagerInfo instance;
     private static MiniMessage miniMessage = MiniMessage.miniMessage();
     private static LocaleConfig localeConfig;
-    //Permissions
-    private static NamespacedKey infoEnabledKey;
+    public static final NamespacedKey INFO_ENABLED_KEY = new NamespacedKey("villagerinfo", "infoEnabled");
+    public static final NamespacedKey HIGHLIGHT_STATUS = new NamespacedKey("villagerinfo", "highlighted");
 
     @Override
     public void onEnable() {
@@ -31,7 +31,6 @@ public final class VillagerInfo extends JavaPlugin {
             this.getLogger().severe("VillagerInfo relies on methods in classes not present on your server. Disabling plugin");
             this.getServer().getPluginManager().disablePlugin(this);
         }
-        infoEnabledKey = new NamespacedKey(VillagerInfo.instance, "infoEnabled");
         localeConfig = new LocaleConfig(this);
         localeConfig.getlocaleConfig();
         Metrics metrics = new Metrics(this, 13653);
@@ -45,9 +44,10 @@ public final class VillagerInfo extends JavaPlugin {
         registerCommands();
     }
 
+    @Override
     public void onDisable() {
         HighlightHandling.WORKSTATION_HIGHLIGHT_BLOCK.forEach((uuid, fallingBlock) -> fallingBlock.remove());
-        HighlightHandling.VILLAGER_PDC.forEach((uuid, persistentDataContainer) -> persistentDataContainer.remove(new NamespacedKey(VillagerInfo.instance, "highlightStatus")));
+        HighlightHandling.VILLAGER_PDC.forEach((uuid, persistentDataContainer) -> persistentDataContainer.remove(HIGHLIGHT_STATUS));
         HighlightHandling.WORKSTATION_HIGHLIGHT_BLOCK.clear();
     }
 
@@ -57,9 +57,6 @@ public final class VillagerInfo extends JavaPlugin {
         CommandHandler.subcommandList.put("reload", new ReloadCommand());
     }
 
-    public static NamespacedKey getInfoEnabledKey() {
-        return infoEnabledKey;
-    }
     public static MiniMessage getMiniMessage(){
         return miniMessage;
     }


### PR DESCRIPTION
This PR uses a Falling Block entity instead of Shulkers to make the highlight more accurate to the block type. It also fixes a minor oversight; the "highlighted" key wouldn't get removed since it was named something else in the `onDisable` method.

![2022-10-18_03 58 31](https://user-images.githubusercontent.com/43185817/196411800-4ed59c0e-4b04-4353-bf24-a745a5d634f6.png)

blocks like the brewing stand are still inaccessible once highlighted.

closes #14 